### PR TITLE
fix(query-form): added validation to origin to make prevent 500 errors.

### DIFF
--- a/components/query-form.tsx
+++ b/components/query-form.tsx
@@ -18,14 +18,13 @@ const QueryForm = () => {
     const { value, id } = e.target;
 
     switch (id) {
-      case 'origin':
-        setOrigin(value);
-        if(value.length >= 4 && !value.startsWith("http")){
-          setError(`${value} needs to start with https protocol!`);
-        }
-        break;
       case 'url':
         setUrl(value);
+        if (value.length >= 5 && !value.startsWith('https')) {
+          setError(`${value} needs to start with https protocol!`);
+        } else {
+          setError(null);
+        }
         break;
       case 'formFactor':
         setFormFactor(value);
@@ -83,9 +82,14 @@ const QueryForm = () => {
           onChange={handleChange}
           className="text-black"
         />
-        {error && <div className="my-3 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
-          <span className="block sm:inline">{error}</span>
-        </div>}
+        {error && (
+          <div
+            className="my-3 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative"
+            role="alert"
+          >
+            <span className="block sm:inline">{error}</span>
+          </div>
+        )}
       </div>
       <div className="flex flex-col">
         <label htmlFor="formFactor">Device type</label>

--- a/components/query-form.tsx
+++ b/components/query-form.tsx
@@ -9,6 +9,7 @@ const QueryForm = () => {
 
   const [origin, setOrigin] = useState<string>(searchParams.get('origin') || '');
   const [formFactor, setFormFactor] = useState<string>(searchParams.get('formFactor') || '');
+  const [error, setError] = useState<string | null>(null);
 
   const handleChange = e => {
     const { value, id } = e.target;
@@ -16,6 +17,9 @@ const QueryForm = () => {
     switch (id) {
       case 'origin':
         setOrigin(value);
+        if(value.length >= 4 && !value.startsWith("http")){
+          setError(`${value} needs to start with https protocol!`);
+        }
         break;
       case 'formFactor':
         setFormFactor(value);
@@ -41,6 +45,9 @@ const QueryForm = () => {
           onChange={handleChange}
           className="text-black"
         />
+        {error && <div className="my-3 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative" role="alert">
+          <span className="block sm:inline">{error}</span>
+        </div>}
       </div>
       <div className="flex flex-col">
         <label htmlFor="formFactor">Device type</label>
@@ -58,6 +65,7 @@ const QueryForm = () => {
       <button
         type="submit"
         className="bg-neutral-700 p-2 py-1 rounded"
+        disabled={error !== null}
       >
         Submit
       </button>


### PR DESCRIPTION
Added validation to the origin, if you don't use the http(s) protocol you then get a 500 error. This ensures you always have some type of protocol before submitting.

[screencast-crux-dashboard.vercel.app-2024.03.28-14_51_12.webm](https://github.com/vercel/crux-history/assets/1409638/e44557db-4414-4fff-848f-5a8168bbf891)

![image](https://github.com/vercel/crux-history/assets/1409638/831fed25-e61e-44a7-b364-6c1d6f7bb01b)

